### PR TITLE
Implement session management features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +236,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "colorchoice"
@@ -287,6 +302,7 @@ dependencies = [
  "mockito",
  "predicates",
  "reqwest",
+ "rustyline",
  "serde",
  "serde_json",
  "tempfile",
@@ -346,6 +362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,10 +384,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "float-cmp"
@@ -532,6 +571,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "http"
@@ -974,6 +1022,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1221,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1382,28 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "rustyline"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "ryu"
@@ -1623,6 +1724,18 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "CLI tool for interacting with the Devin API"
 authors = ["Devin AI <devin-ai-integration[bot]@users.noreply.github.com>"]
-license = "MIT"
+license = "BSD-3-Clause"
 readme = "README.md"
 repository = "https://github.com/appwiz/devin-cli"
 
@@ -17,6 +17,7 @@ reqwest = { version = "0.11", features = ["json", "blocking"] }
 anyhow = "1.0"
 thiserror = "1.0"
 colored = "2.0"
+rustyline = "15.0.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, Devin AI
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
-# devin-cli
+# Devin CLI
+
+A command-line interface for interacting with the Devin AI API.
+
+## Installation
+
+```bash
+cargo install devin
+```
+
+Or clone the repository and build from source:
+
+```bash
+git clone https://github.com/appwiz/devin-cli.git
+cd devin-cli
+cargo build --release
+```
+
+## Configuration
+
+Before using the CLI, you need to configure your API token:
+
+```bash
+devin configure <your-api-token>
+```
+
+You can also set the token using the `DEVIN_API_TOKEN` environment variable.
+
+## Usage
+
+### Interactive Session
+
+Start an interactive session with Devin:
+
+```bash
+devin
+```
+
+This will open a shell-like interface where you can send messages to Devin and receive responses:
+
+```
+> my prompt
+responses
+responses
+> my prompt
+responses
+responses
+```
+
+### Slash Commands
+
+The interactive session supports the following slash commands:
+
+- `/quit` - Exit the session
+- `/help` - Show help message
+- `/sessions` - List all available sessions
+- `/connect <session_id>` - Connect to an existing session
+
+### Connect to Existing Session
+
+You can connect to an existing session using the `--session-id` option:
+
+```bash
+devin session --session-id <session-id>
+```
+
+Or using the shorter form:
+
+```bash
+devin session -s <session-id>
+```
+
+### Other Commands
+
+- `devin show` - Show the configured API token
+- `devin doctor` - Check if the CLI is set up correctly
+
+## API Documentation
+
+For more information about the Devin API, see the [official documentation](https://docs.devin.ai/api-reference/overview).
+
+## License
+
+This project is licensed under the BSD 3-Clause License - see the [LICENSE](LICENSE) file for details.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,1 +1,2 @@
 pub mod client;
+pub mod models;

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateSessionRequest {
+    pub prompt: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateSessionResponse {
+    pub session_id: String,
+    pub url: String,
+    pub is_new_session: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SendMessageRequest {
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MessageResponse {
+    pub message: String,
+    pub done: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SessionDetails {
+    pub session_id: String,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListSessionsResponse {
+    pub sessions: Vec<SessionDetails>,
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod configure;
 pub mod show;
 pub mod doctor;
+pub mod session;

--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -1,0 +1,204 @@
+use crate::api::client::ApiClient;
+use crate::config::get_api_token;
+use anyhow::{anyhow, Result};
+use colored::Colorize;
+use rustyline::error::ReadlineError;
+use rustyline::DefaultEditor;
+
+// Slash commands
+const CMD_QUIT: &str = "/quit";
+const CMD_HELP: &str = "/help";
+const CMD_SESSIONS: &str = "/sessions";
+const CMD_CONNECT: &str = "/connect";
+
+pub fn execute(session_id: Option<&str>) -> Result<()> {
+    // Get API token
+    let token = match get_api_token() {
+        Ok(token) => token,
+        Err(e) => {
+            println!("{} {}", "✗ API token not configured:".red(), e);
+            println!("\nRun 'devin configure <token>' to set up your API token.");
+            return Err(e.into());
+        }
+    };
+    
+    // Create API client
+    let api_client = ApiClient::new(&token);
+    
+    // Initialize readline
+    let mut rl = DefaultEditor::new()?;
+    
+    // Connect to existing session or create a new one
+    let mut current_session_id = match session_id {
+        Some(id) => {
+            println!("Connecting to existing session {}...", id);
+            match api_client.get_session_details(id) {
+                Ok(_) => {
+                    println!("{}", "✓ Connected to session".green());
+                    id.to_string()
+                },
+                Err(e) => {
+                    println!("{} {}", "✗ Failed to connect to session:".red(), e);
+                    return Err(anyhow!("Failed to connect to session: {}", e));
+                }
+            }
+        },
+        None => String::new()
+    };
+    
+    println!("Welcome to Devin CLI");
+    println!("Type {} to exit, {} for help", CMD_QUIT.yellow(), CMD_HELP.yellow());
+    
+    // Main interaction loop
+    loop {
+        let prompt = if current_session_id.is_empty() {
+            "> ".to_string()
+        } else {
+            format!("[{}] > ", current_session_id)
+        };
+        
+        let readline = rl.readline(&prompt);
+        match readline {
+            Ok(line) => {
+                // Add to history
+                rl.add_history_entry(&line)?;
+                
+                // Process the input
+                if line.trim().is_empty() {
+                    continue;
+                }
+                
+                // Handle slash commands
+                if line.starts_with('/') {
+                    match line.trim() {
+                        CMD_QUIT => {
+                            println!("Goodbye!");
+                            break;
+                        },
+                        CMD_HELP => {
+                            println!("Available commands:");
+                            println!("  {} - Exit the session", CMD_QUIT.yellow());
+                            println!("  {} - Show this help message", CMD_HELP.yellow());
+                            println!("  {} - List all sessions", CMD_SESSIONS.yellow());
+                            println!("  {} <session_id> - Connect to an existing session", CMD_CONNECT.yellow());
+                            println!("Any other input will be sent as a message to Devin.");
+                        },
+                        cmd if cmd.starts_with(CMD_CONNECT) => {
+                            let parts: Vec<&str> = cmd.split_whitespace().collect();
+                            if parts.len() < 2 {
+                                println!("Usage: {} <session_id>", CMD_CONNECT.yellow());
+                                continue;
+                            }
+                            
+                            let new_session_id = parts[1];
+                            match api_client.get_session_details(new_session_id) {
+                                Ok(_) => {
+                                    println!("{} {}", "✓ Connected to session".green(), new_session_id);
+                                    current_session_id = new_session_id.to_string();
+                                },
+                                Err(e) => {
+                                    println!("{} {}", "✗ Failed to connect to session:".red(), e);
+                                }
+                            }
+                        },
+                        CMD_SESSIONS => {
+                            match api_client.list_sessions() {
+                                Ok(sessions) => {
+                                    if sessions.is_empty() {
+                                        println!("No sessions found.");
+                                    } else {
+                                        println!("Available sessions:");
+                                        for session in sessions {
+                                            println!("  {} (created: {})", session.session_id, session.created_at);
+                                        }
+                                    }
+                                },
+                                Err(e) => {
+                                    println!("{} {}", "✗ Failed to list sessions:".red(), e);
+                                }
+                            }
+                        },
+                        _ => {
+                            println!("Unknown command. Type {} for help.", CMD_HELP.yellow());
+                        }
+                    }
+                    continue;
+                }
+                
+                // Send message to Devin
+                if current_session_id.is_empty() {
+                    // Create a new session with the first message
+                    match api_client.create_session(&line) {
+                        Ok(session_id) => {
+                            println!("{} {}", "✓ Created new session:".green(), session_id);
+                            current_session_id = session_id;
+                            
+                            // Wait for and display the response
+                            match api_client.send_message(&current_session_id, "") {
+                                Ok(response) => {
+                                    println!("{}", response.message);
+                                },
+                                Err(e) => {
+                                    println!("{} {}", "✗ Failed to get response:".red(), e);
+                                }
+                            }
+                        },
+                        Err(e) => {
+                            println!("{} {}", "✗ Failed to create session:".red(), e);
+                        }
+                    }
+                } else {
+                    // Send message to existing session
+                    match api_client.send_message(&current_session_id, &line) {
+                        Ok(response) => {
+                            println!("{}", response.message);
+                        },
+                        Err(e) => {
+                            println!("{} {}", "✗ Failed to send message:".red(), e);
+                        }
+                    }
+                }
+            },
+            Err(ReadlineError::Interrupted) => {
+                println!("CTRL-C");
+                break;
+            },
+            Err(ReadlineError::Eof) => {
+                println!("CTRL-D");
+                break;
+            },
+            Err(err) => {
+                println!("Error: {:?}", err);
+                break;
+            }
+        }
+    }
+    
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+    
+    #[test]
+    fn test_execute_no_token() {
+        // Save the original token
+        let original_token = env::var("DEVIN_API_TOKEN").ok();
+        
+        // Ensure no token is set
+        env::remove_var("DEVIN_API_TOKEN");
+        
+        // Execute the command
+        let result = execute(None);
+        
+        // Restore the original token
+        if let Some(token) = original_token {
+            env::set_var("DEVIN_API_TOKEN", token);
+        }
+        
+        // Check the result
+        assert!(result.is_err());
+    }
+}

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -33,7 +33,7 @@ pub fn mask_token(token: &str) -> String {
 mod tests {
     use super::*;
     use std::env;
-    use tempfile::tempdir;
+    // Removed unused import
     
     #[test]
     fn test_mask_token() {

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -144,6 +144,6 @@ mod tests {
     #[ignore]
     fn test_missing_token() {
         // This test is skipped due to environment isolation issues
-        // The functionality is tested in the integration tests
+        // The functionality is tested in the integration tests and in the session command tests
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,13 @@ enum Commands {
     
     /// Check if the CLI is set up correctly
     Doctor,
+    
+    /// Start an interactive session with Devin
+    Session {
+        /// Optional session ID to connect to an existing session
+        #[arg(short, long)]
+        session_id: Option<String>,
+    },
 }
 
 fn main() -> Result<()> {
@@ -40,9 +47,12 @@ fn main() -> Result<()> {
         Some(Commands::Doctor) => {
             commands::doctor::execute()
         }
+        Some(Commands::Session { session_id }) => {
+            commands::session::execute(session_id.as_deref())
+        }
         None => {
-            println!("No command specified. Use --help for usage information.");
-            Ok(())
+            // If no command is specified, start an interactive session
+            commands::session::execute(None)
         }
     }
 }

--- a/tests/integration/cli_test.rs
+++ b/tests/integration/cli_test.rs
@@ -65,10 +65,30 @@ mod tests {
         // It's difficult to ensure no token is configured in the test environment
     }
     
-    #[test]
+   #[test]
     #[ignore]
     fn test_doctor_command_without_token() {
         // This test is skipped due to environment isolation issues
         // It's difficult to ensure no token is configured in the test environment
+    }
+    
+    #[test]
+    fn test_session_command_help() {
+        // Set the environment variable for testing
+        env::set_var("DEVIN_API_TOKEN", "test-token-cli");
+        
+        // Run the session command with help
+        let mut cmd = Command::cargo_bin("devin").unwrap();
+        cmd.arg("session");
+        cmd.write_stdin("/help\n/quit\n");
+        cmd.assert().success()
+            .stdout(predicate::str::contains("Available commands:"))
+            .stdout(predicate::str::contains("/quit"))
+            .stdout(predicate::str::contains("/help"))
+            .stdout(predicate::str::contains("/sessions"))
+            .stdout(predicate::str::contains("/connect"));
+        
+        // Clean up
+        env::remove_var("DEVIN_API_TOKEN");
     }
 }


### PR DESCRIPTION
This PR implements the ability to start a session as a shell, send messages and interact with Devin within that session, quit the session, and (re)connect to an existing session.

Features implemented:
- Interactive shell-like CLI interface with persistent prompt
- Slash commands (/quit, /help, /sessions, /connect)
- Session creation, message sending, and reconnection functionality
- API client with session management methods
- Comprehensive documentation in README
- BSD 3-Clause License

Link to Devin run: https://app.devin.ai/sessions/44284b8d88f745f59999d6a8c865349b
Requested by: Rohan.Deshpande@gs.com